### PR TITLE
Refactor Claude.md for new .claude folder structure

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -2,17 +2,26 @@
 
 This file provides guidance for Claude Code when working with the UnoClaude project. It references specific documentation files for different architectural components.
 
-## Documentation Structure
+## Important Note on Documentation Sources
 
-- [Architecture Overview](./docs/architecture/README.md) - Pages, Regions, and Navigation patterns
-- [ViewModels and Models](./docs/mvvm/README.md) - Uno.Extensions.Reactive and MVUX patterns
-- [XAML Styling Guidelines](./docs/styling/README.md) - Consistent styling approach
-- [Services Architecture](./docs/services/README.md) - Service layer and Mediator pattern implementation
+**Primary Documentation**: Always refer to the project-specific documentation in `.claude/docs/` first. These are tailored specifically for this project.
+
+**Extended Documentation**: The `.claude/docs/extendeddocs/` folder contains comprehensive documentation from Uno Platform, Uno Extensions, Uno Toolkit UI, and Shiny libraries. These should be consulted ONLY when:
+- You need specific implementation details not covered in the primary docs
+- You're implementing advanced features that require deeper platform knowledge
+- The primary documentation references a specific feature from these libraries
+
+## Primary Documentation Structure
+
+- [Architecture Overview](./.claude/docs/architecture/README.md) - Pages, Regions, and Navigation patterns
+- [ViewModels and Models](./.claude/docs/mvvm/README.md) - Uno.Extensions.Reactive and MVUX patterns
+- [XAML Styling Guidelines](./.claude/docs/styling/README.md) - Consistent styling approach
+- [Services Architecture](./.claude/docs/services/README.md) - Service layer and Mediator pattern implementation
 
 ### Uno Hosting & Configuration
-- [App Startup Structure](./docs/uno-hosting/CLAUDE_App_Startup_Structure.md) - Uno app initialization and hosting
-- [Navigation Registration](./docs/uno-hosting/CLAUDE_Navigation_Registration.md) - Route and view registration patterns
-- [Service Registration Pattern](./docs/uno-hosting/CLAUDE_Service_Registration_Pattern.md) - DI and service configuration
+- [App Startup Structure](./.claude/docs/uno-hosting/CLAUDE_App_Startup_Structure.md) - Uno app initialization and hosting
+- [Navigation Registration](./.claude/docs/uno-hosting/CLAUDE_Navigation_Registration.md) - Route and view registration patterns
+- [Service Registration Pattern](./.claude/docs/uno-hosting/CLAUDE_Service_Registration_Pattern.md) - DI and service configuration
 
 ## Quick Reference
 
@@ -20,11 +29,18 @@ This file provides guidance for Claude Code when working with the UnoClaude proj
 ```
 UnoClaude/
 ├── Claude.md (this file)
-├── docs/
-│   ├── architecture/
-│   ├── mvvm/
-│   ├── styling/
-│   └── services/
+├── .claude/
+│   └── docs/
+│       ├── architecture/
+│       ├── mvvm/
+│       ├── styling/
+│       ├── services/
+│       ├── uno-hosting/
+│       └── extendeddocs/      # Reference docs - use only when needed
+│           ├── shiny/          # Shiny Mediator documentation
+│           ├── unoextensions/  # Uno.Extensions documentation
+│           ├── unoplatform/    # Uno Platform core documentation
+│           └── unotoolkitui/   # Uno Toolkit UI documentation
 └── src/
     ├── Pages/
     │   ├── Main/
@@ -50,3 +66,14 @@ UnoClaude/
 4. **Services**: Use Shiny Mediator Pattern for API and messaging
 
 For detailed information, refer to the specific documentation files linked above.
+
+## Extended Documentation Reference
+
+When you need specific platform or library details not covered in the primary docs:
+
+- **Shiny Mediator**: `.claude/docs/extendeddocs/shiny/` - For mediator patterns, commands, events
+- **Uno Extensions**: `.claude/docs/extendeddocs/unoextensions/` - For MVUX, navigation, reactive patterns
+- **Uno Platform**: `.claude/docs/extendeddocs/unoplatform/` - For platform-specific features, controls
+- **Uno Toolkit UI**: `.claude/docs/extendeddocs/unotoolkitui/` - For UI controls and styling
+
+**Remember**: Always check the primary project documentation first!


### PR DESCRIPTION
## Summary
- Updated Claude.md to reflect the new documentation structure in `.claude/docs/`
- Added clear guidance about when to use extendeddocs vs primary documentation
- Updated all documentation links to point to the correct new locations

## Changes
1. **Documentation hierarchy clarification**: Added a section explaining that primary docs should be used first, and extendeddocs only for specific implementation details
2. **Path updates**: Changed all documentation paths from `./docs/` to `./.claude/docs/`
3. **Project structure update**: Updated the ASCII diagram to show the new folder structure including extendeddocs
4. **Extended documentation reference**: Added a section listing what's available in each extendeddocs subfolder

## Test plan
- [ ] Verify all documentation links work correctly
- [ ] Confirm Claude.md provides clear guidance on documentation usage

🤖 Generated with [Claude Code](https://claude.ai/code)